### PR TITLE
Add LangChain LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ A modular AI chat backend based on FastAPI and LangChain.
    ```bash
    poetry run python -m ai_chat_backend.api.cli
    ```
+
+## LLM Integration
+
+Agents use LangChain's `ChatOpenAI` class to call OpenRouter models. Set the
+following environment variables before running the server or CLI:
+
+```bash
+export OPENAI_API_KEY="<your-openrouter-key>"
+export OPENAI_API_BASE="https://openrouter.ai/api/v1"
+```
+
+Tests run without network access by patching the LLM class, so no API key is
+required for running the test suite.

--- a/agents.yaml
+++ b/agents.yaml
@@ -2,6 +2,10 @@ agents:
   - name: DefaultAgent
     class_path: ai_chat_backend.agents.default_agent.DefaultAgent
     description: "General purpose agent"
+    model: gpt-3.5-turbo
+    system_prompt: "You are a helpful general-purpose assistant."
   - name: MathAgent
     class_path: ai_chat_backend.agents.math_agent.MathAgent
     description: "Handles math queries"
+    model: gpt-3.5-turbo
+    system_prompt: "You are a math expert AI that solves problems step by step."

--- a/agents.yaml
+++ b/agents.yaml
@@ -2,10 +2,12 @@ agents:
   - name: DefaultAgent
     class_path: ai_chat_backend.agents.default_agent.DefaultAgent
     description: "General purpose agent"
+    keywords: []
     model: gpt-3.5-turbo
     system_prompt: "You are a helpful general-purpose assistant."
   - name: MathAgent
     class_path: ai_chat_backend.agents.math_agent.MathAgent
     description: "Handles math queries"
+    keywords: ["math", "calculate", "addition", "subtraction", "multiply", "divide"]
     model: gpt-3.5-turbo
     system_prompt: "You are a math expert AI that solves problems step by step."

--- a/ai_chat_backend/agents/base.py
+++ b/ai_chat_backend/agents/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Dict, Type, Any
+from typing import Dict, Type, Any, List
 
 try:
     from langchain.chat_models import ChatOpenAI  # type: ignore
@@ -33,13 +33,28 @@ class AgentMeta(type):
         if agent_name:
             AGENT_REGISTRY[agent_name] = cls
 
+
 class Agent(metaclass=AgentMeta):
     agent_name: str = ""
+    # Each agent can specify routing keywords.  This supports the Open/Closed
+    # Principle by allowing new agents to declare their own keywords without
+    # modifying the router.
+    keywords: List[str] = []
     system_prompt: str = "You are a helpful assistant."
 
-    def __init__(self, description: str = "", model_name: str | None = None) -> None:
+    def __init__(
+        self,
+        description: str = "",
+        model_name: str | None = None,
+        keywords: List[str] | None = None,
+    ) -> None:
         self.description = description
         self.model_name = model_name or "gpt-3.5-turbo"
+
+        if keywords is not None:
+            # Instances override the class-level default keywords so strategies
+            # can rely on per-agent configuration.
+            self.keywords = keywords
 
         if ChatOpenAI is not None:
             # Ensure OpenRouter endpoint is used if no base specified

--- a/ai_chat_backend/agents/default_agent.py
+++ b/ai_chat_backend/agents/default_agent.py
@@ -4,6 +4,8 @@ class DefaultAgent(Agent):
     """Fallback agent for general questions."""
 
     agent_name = "DefaultAgent"
+    # No specific keywords; acts as a catch-all agent.
+    keywords: list[str] = []
     system_prompt = "You are a helpful general-purpose assistant."
 
     def generate_response(self, message: str) -> str:

--- a/ai_chat_backend/agents/default_agent.py
+++ b/ai_chat_backend/agents/default_agent.py
@@ -4,6 +4,7 @@ class DefaultAgent(Agent):
     """Fallback agent for general questions."""
 
     agent_name = "DefaultAgent"
+    system_prompt = "You are a helpful general-purpose assistant."
 
     def generate_response(self, message: str) -> str:
-        return "I'm a default agent responding to: " + message
+        return super().generate_response(message)

--- a/ai_chat_backend/agents/math_agent.py
+++ b/ai_chat_backend/agents/math_agent.py
@@ -4,6 +4,7 @@ class MathAgent(Agent):
     """Agent specialized in math questions."""
 
     agent_name = "MathAgent"
+    keywords = ["math", "calculate", "addition", "subtraction", "multiply", "divide"]
     system_prompt = "You are a math expert AI that solves problems step by step."
 
     def generate_response(self, message: str) -> str:

--- a/ai_chat_backend/agents/math_agent.py
+++ b/ai_chat_backend/agents/math_agent.py
@@ -4,7 +4,7 @@ class MathAgent(Agent):
     """Agent specialized in math questions."""
 
     agent_name = "MathAgent"
+    system_prompt = "You are a math expert AI that solves problems step by step."
 
     def generate_response(self, message: str) -> str:
-        # Placeholder for actual math handling logic
-        return "MathAgent received: " + message
+        return super().generate_response(message)

--- a/ai_chat_backend/config/loader.py
+++ b/ai_chat_backend/config/loader.py
@@ -68,5 +68,10 @@ class ConfigManager:
             module_name, class_name = agent_cfg.class_path.rsplit(".", 1)
             module = importlib.import_module(module_name)
             cls = getattr(module, class_name)
-            agents[agent_cfg.name] = cls(agent_cfg.description)
+            agents[agent_cfg.name] = cls(
+                agent_cfg.description,
+                model_name=agent_cfg.model,
+            )
+            if agent_cfg.system_prompt:
+                agents[agent_cfg.name].system_prompt = agent_cfg.system_prompt
         return agents

--- a/ai_chat_backend/config/loader.py
+++ b/ai_chat_backend/config/loader.py
@@ -48,7 +48,13 @@ class ConfigManager:
                 line = line.lstrip()[1:].strip()
             if ":" in line:
                 key, value = line.split(":", 1)
-                current[key.strip()] = value.strip().strip('"')
+                value = value.strip()
+                if value.startswith("[") and value.endswith("]"):
+                    items = value[1:-1].split(',')
+                    value = [item.strip().strip('"').strip("'") for item in items if item.strip()]
+                else:
+                    value = value.strip('"')
+                current[key.strip()] = value
         return result
 
     def instantiate_agents(self):
@@ -71,6 +77,7 @@ class ConfigManager:
             agents[agent_cfg.name] = cls(
                 agent_cfg.description,
                 model_name=agent_cfg.model,
+                keywords=agent_cfg.keywords,
             )
             if agent_cfg.system_prompt:
                 agents[agent_cfg.name].system_prompt = agent_cfg.system_prompt

--- a/ai_chat_backend/config/schema.py
+++ b/ai_chat_backend/config/schema.py
@@ -6,6 +6,8 @@ class AgentConfig(BaseModel):
     name: str
     class_path: str
     description: str = ""
+    # Optional list of keywords used by routing strategies.
+    keywords: List[str] = []
     model: str | None = None
     system_prompt: str | None = None
 

--- a/ai_chat_backend/config/schema.py
+++ b/ai_chat_backend/config/schema.py
@@ -6,6 +6,8 @@ class AgentConfig(BaseModel):
     name: str
     class_path: str
     description: str = ""
+    model: str | None = None
+    system_prompt: str | None = None
 
 class Config(BaseModel):
     agents: List[AgentConfig]

--- a/ai_chat_backend/router/router_agent.py
+++ b/ai_chat_backend/router/router_agent.py
@@ -4,7 +4,8 @@ from typing import Dict
 
 from ..agents.base import AGENT_REGISTRY, Agent
 from ..config.loader import ConfigManager
-from .strategy import RoutingStrategy, SimpleStrategy
+
+from .strategy import RoutingStrategy, KeywordRoutingStrategy
 
 class RouterAgent:
     """Select the appropriate agent to handle a user message."""
@@ -13,7 +14,11 @@ class RouterAgent:
         # Dependency injection of collaborators keeps the router flexible and
         # testable. When ``agents`` is ``None`` we fall back to the registry of
         # statically defined agents, preserving backward compatibility.
-        self.strategy = strategy or SimpleStrategy()
+
+        # Use a keyword-based routing strategy by default to better match user
+        # intent.  The *Strategy* pattern allows swapping this out for a more
+        # advanced LLM-driven strategy without modifying this class.
+        self.strategy = strategy or KeywordRoutingStrategy()
         if agents is None:
             agents = {name: cls() for name, cls in AGENT_REGISTRY.items()}
         self.agents = agents

--- a/ai_chat_backend/router/strategy.py
+++ b/ai_chat_backend/router/strategy.py
@@ -1,9 +1,34 @@
 from __future__ import annotations
 
+from typing import Dict
+
+from ..agents.base import Agent
+
+
 class RoutingStrategy:
-    def choose_agent(self, user_message: str, agents: dict) -> str:
+    """Strategy interface for choosing an agent."""
+
+    def choose_agent(self, user_message: str, agents: Dict[str, Agent]) -> str:
         raise NotImplementedError
 
+
 class SimpleStrategy(RoutingStrategy):
-    def choose_agent(self, user_message: str, agents: dict) -> str:
+    """Trivial strategy that always selects the first agent."""
+
+    def choose_agent(self, user_message: str, agents: Dict[str, Agent]) -> str:
         return next(iter(agents))
+
+
+class KeywordRoutingStrategy(RoutingStrategy):
+    """Route messages by matching configured keywords."""
+
+    def choose_agent(self, user_message: str, agents: Dict[str, Agent]) -> str:
+        message = user_message.lower()
+        for name, agent in agents.items():
+            for kw in getattr(agent, "keywords", []):
+                if kw.lower() in message:
+                    return name
+        # Fallback to default ordering when no keywords match. This reuse of
+        # ``SimpleStrategy`` demonstrates the *Strategy* pattern and keeps each
+        # strategy small and focused (Single Responsibility Principle).
+        return SimpleStrategy().choose_agent(user_message, agents)

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -23,8 +23,14 @@ def test_config_manager_instantiates_agents():
     assert set(agents.keys()) == {"DefaultAgent", "MathAgent"}
     assert isinstance(agents["DefaultAgent"], DefaultAgent)
     assert agents["DefaultAgent"].description == "General purpose agent"
+    assert agents["DefaultAgent"].model_name == "gpt-3.5-turbo"
+    assert (
+        agents["DefaultAgent"].system_prompt
+        == "You are a helpful general-purpose assistant."
+    )
     assert isinstance(agents["MathAgent"], MathAgent)
     assert agents["MathAgent"].description == "Handles math queries"
+    assert agents["MathAgent"].model_name == "gpt-3.5-turbo"
 
 
 def test_router_agent_from_config():
@@ -32,4 +38,4 @@ def test_router_agent_from_config():
     assert isinstance(router.agents["DefaultAgent"], DefaultAgent)
     assert isinstance(router.agents["MathAgent"], MathAgent)
     response = router.generate_response("hello")
-    assert response.startswith("I'm a default agent")
+    assert response.startswith("ECHO:")

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -28,9 +28,11 @@ def test_config_manager_instantiates_agents():
         agents["DefaultAgent"].system_prompt
         == "You are a helpful general-purpose assistant."
     )
+    assert agents["DefaultAgent"].keywords == []
     assert isinstance(agents["MathAgent"], MathAgent)
     assert agents["MathAgent"].description == "Handles math queries"
     assert agents["MathAgent"].model_name == "gpt-3.5-turbo"
+    assert "math" in agents["MathAgent"].keywords
 
 
 def test_router_agent_from_config():

--- a/tests/test_keyword_strategy.py
+++ b/tests/test_keyword_strategy.py
@@ -1,0 +1,36 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ai_chat_backend.router.strategy import KeywordRoutingStrategy
+from ai_chat_backend.router.router_agent import RouterAgent
+from ai_chat_backend.config.loader import ConfigManager
+
+
+def get_config_path() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1] / "agents.yaml"
+
+
+def test_keyword_routing_strategy_selects_math_agent():
+    manager = ConfigManager(str(get_config_path()))
+    agents = manager.instantiate_agents()
+    strategy = KeywordRoutingStrategy()
+    router = RouterAgent(agents=agents, strategy=strategy)
+
+    result = router.strategy.choose_agent("please help me with math", router.agents)
+    assert result == "MathAgent"
+    response = router.generate_response("calculate 2 + 2")
+    assert response.startswith("ECHO:")
+
+
+def test_keyword_routing_strategy_falls_back_to_default():
+    manager = ConfigManager(str(get_config_path()))
+    agents = manager.instantiate_agents()
+    strategy = KeywordRoutingStrategy()
+    router = RouterAgent(agents=agents, strategy=strategy)
+
+    result = router.strategy.choose_agent("tell me a joke", router.agents)
+    assert result == "DefaultAgent"
+    response = router.generate_response("hello")
+    assert response.startswith("ECHO:")

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from ai_chat_backend.agents.default_agent import DefaultAgent
+from ai_chat_backend.agents.base import ChatOpenAI
+
+class DummyLLM:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, messages):
+        return SimpleNamespace(content="LLM Response")
+
+
+def test_default_agent_uses_llm(monkeypatch):
+    monkeypatch.setattr('ai_chat_backend.agents.base.ChatOpenAI', DummyLLM)
+    agent = DefaultAgent()
+    assert agent.generate_response('hi') == 'LLM Response'


### PR DESCRIPTION
## Summary
- support ChatOpenAI from OpenRouter in the Agent base class
- include model and prompt settings in config and YAML file
- update DefaultAgent and MathAgent to use the base implementation
- document environment variables needed for OpenRouter
- add tests covering new config fields and LLM usage

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agents now support configurable language model selection and custom system prompts for tailored behavior.
  - Agents generate responses using integrated language models, with improved handling for both general and math-specific tasks.
  - Introduced keyword-based routing strategy to direct messages to specialized agents based on message content.

- **Configuration**
  - Agent configuration files now accept model, system prompt, and keyword fields for each agent.
  - Enhanced configuration parsing to support list values for keywords.

- **Documentation**
  - Updated README with instructions for setting up LLM integration and environment variables.

- **Tests**
  - Added and enhanced tests to verify agent instantiation, configuration, language model integration, and keyword routing strategy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->