### PR TITLE
Enable OpenRouter configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,28 @@ A modular AI chat backend based on FastAPI and LangChain.
    ```bash
    poetry run python -m ai_chat_backend.api.cli
    ```
+
+## Using OpenRouter
+
+The agents use LangChain's `ChatOpenAI` client which reads the following
+environment variables:
+
+* `OPENAI_API_KEY` – your OpenRouter token.
+* `OPENAI_API_BASE` – the OpenRouter API endpoint
+  (`https://openrouter.ai/api/v1`).
+
+Set these variables before running the server or CLI. The selected model for
+each agent is defined in `agents.yaml` under the `model` field.
+
+### Quick test
+
+To experiment from the command line after configuring your token, run:
+
+```bash
+export OPENAI_API_KEY=your-token
+export OPENAI_API_BASE=https://openrouter.ai/api/v1
+poetry run python scripts/chat_demo.py
+```
+
+Type messages at the prompt to chat with the default backend agent. Use `exit`
+to quit.

--- a/agents.yaml
+++ b/agents.yaml
@@ -3,7 +3,9 @@ agents:
     class_path: ai_chat_backend.agents.default_agent.DefaultAgent
     description: "General purpose agent"
     keywords: []
+    model: openrouter/gpt-3.5-turbo
   - name: MathAgent
     class_path: ai_chat_backend.agents.math_agent.MathAgent
     description: "Handles math queries"
     keywords: ["math", "calculate", "addition", "subtraction", "multiply", "divide"]
+    model: openrouter/gpt-3.5-turbo

--- a/ai_chat_backend/agents/base.py
+++ b/ai_chat_backend/agents/base.py
@@ -18,13 +18,22 @@ class Agent(metaclass=AgentMeta):
     # Principle by allowing new agents to declare their own keywords without
     # modifying the router.
     keywords: List[str] = []
+    # Default model name; subclasses can override.
+    model_name: str = ""
 
-    def __init__(self, description: str = "", keywords: List[str] | None = None) -> None:
+    def __init__(
+        self,
+        description: str = "",
+        keywords: List[str] | None = None,
+        model: str | None = None,
+    ) -> None:
         self.description = description
         if keywords is not None:
             # Instances override the class-level default keywords so strategies
             # can rely on per-agent configuration.
             self.keywords = keywords
+        if model is not None:
+            self.model_name = model
 
     def generate_response(self, message: str) -> str:
         raise NotImplementedError

--- a/ai_chat_backend/agents/default_agent.py
+++ b/ai_chat_backend/agents/default_agent.py
@@ -1,3 +1,12 @@
+import os
+
+try:  # pragma: no cover - allow running without langchain installed
+    from langchain.chat_models import ChatOpenAI
+    from langchain.schema import HumanMessage, SystemMessage
+except ModuleNotFoundError:  # pragma: no cover - dependency optional for tests
+    ChatOpenAI = None  # type: ignore
+    HumanMessage = SystemMessage = None
+
 from .base import Agent
 
 class DefaultAgent(Agent):
@@ -7,5 +16,22 @@ class DefaultAgent(Agent):
     # No specific keywords; acts as a catch-all agent.
     keywords: list[str] = []
 
+    model_name = "openrouter/gpt-3.5-turbo"
+
+    def __init__(self, description: str = "", keywords: list[str] | None = None, model: str | None = None) -> None:
+        super().__init__(description, keywords, model=model)
+        self.system_prompt = self.description or "You are a helpful assistant."
+        key = os.getenv("OPENAI_API_KEY")
+        if key and key != "test" and ChatOpenAI is not None:
+            # Only create the LLM client when we have a real API key and LangChain is available.
+            self.llm = ChatOpenAI(model_name=self.model_name)
+        else:
+            self.llm = None
+
     def generate_response(self, message: str) -> str:
-        return "I'm a default agent responding to: " + message
+        if self.llm is None or HumanMessage is None:
+            return "I'm a default agent responding to: " + message
+
+        messages = [SystemMessage(content=self.system_prompt), HumanMessage(content=message)]
+        response = self.llm(messages)
+        return response.content

--- a/ai_chat_backend/agents/math_agent.py
+++ b/ai_chat_backend/agents/math_agent.py
@@ -6,6 +6,9 @@ class MathAgent(Agent):
     agent_name = "MathAgent"
     keywords = ["math", "calculate", "addition", "subtraction", "multiply", "divide"]
 
+    def __init__(self, description: str = "", keywords: list[str] | None = None, model: str | None = None) -> None:
+        super().__init__(description, keywords, model=model)
+
     def generate_response(self, message: str) -> str:
         # Placeholder for actual math handling logic
         return "MathAgent received: " + message

--- a/ai_chat_backend/config/loader.py
+++ b/ai_chat_backend/config/loader.py
@@ -74,5 +74,9 @@ class ConfigManager:
             module_name, class_name = agent_cfg.class_path.rsplit(".", 1)
             module = importlib.import_module(module_name)
             cls = getattr(module, class_name)
-            agents[agent_cfg.name] = cls(agent_cfg.description, keywords=agent_cfg.keywords)
+            agents[agent_cfg.name] = cls(
+                agent_cfg.description,
+                keywords=agent_cfg.keywords,
+                model=agent_cfg.model,
+            )
         return agents

--- a/ai_chat_backend/config/schema.py
+++ b/ai_chat_backend/config/schema.py
@@ -8,6 +8,8 @@ class AgentConfig(BaseModel):
     description: str = ""
     # Optional list of keywords used by routing strategies.
     keywords: List[str] = []
+    # Optional model name used by the agent (e.g. openrouter/gpt-4).
+    model: str | None = None
 
 class Config(BaseModel):
     agents: List[AgentConfig]

--- a/ai_chat_backend/router/router_agent.py
+++ b/ai_chat_backend/router/router_agent.py
@@ -16,10 +16,9 @@ class RouterAgent:
         # statically defined agents, preserving backward compatibility.
 
         # Use a keyword-based routing strategy by default to better match user
-        # intent.  The *Strategy* pattern allows swapping this out for a more
+        # intent. The *Strategy* pattern allows swapping this out for a more
         # advanced LLM-driven strategy without modifying this class.
         self.strategy = strategy or KeywordRoutingStrategy()
-        self.strategy = strategy or SimpleStrategy()
         if agents is None:
             agents = {name: cls() for name, cls in AGENT_REGISTRY.items()}
         self.agents = agents

--- a/scripts/chat_demo.py
+++ b/scripts/chat_demo.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from ai_chat_backend.router.router_agent import RouterAgent
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "agents.yaml"
+
+
+def main() -> None:
+    router = RouterAgent.from_config(str(CONFIG_PATH))
+    print("Type messages (enter 'exit' to quit):")
+    while True:
+        msg = input('> ')
+        if msg.lower() == 'exit':
+            break
+        print(router.generate_response(msg))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -24,6 +24,7 @@ def test_config_manager_instantiates_agents():
     assert isinstance(agents["DefaultAgent"], DefaultAgent)
     assert agents["DefaultAgent"].description == "General purpose agent"
     assert agents["DefaultAgent"].keywords == []
+    assert agents["DefaultAgent"].model_name.endswith("gpt-3.5-turbo")
     assert isinstance(agents["MathAgent"], MathAgent)
     assert agents["MathAgent"].description == "Handles math queries"
     assert "math" in agents["MathAgent"].keywords


### PR DESCRIPTION
## Summary
- integrate optional model and ChatOpenAI usage in DefaultAgent
- support `model` field in configuration schema and YAML
- fix router default strategy
- provide demo script and update docs
- extend tests for new configuration field

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for specifying language model names per agent via configuration.
  - Added a command-line chat demo script for interactive testing.
- **Documentation**
  - Updated README with instructions for using OpenRouter, setting environment variables, and running a quick test.
- **Bug Fixes**
  - Corrected default routing strategy to use keyword-based routing.
- **Tests**
  - Enhanced tests to verify correct model assignment for agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->